### PR TITLE
Catch console exit

### DIFF
--- a/AlternateVoice.Server.Dummy/src/Program.cs
+++ b/AlternateVoice.Server.Dummy/src/Program.cs
@@ -90,7 +90,10 @@ namespace AlternateVoice.Server.Dummy
             }
         }
 
-        private static void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e) => ExitApplication();
+        private static void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            ExitApplication();
+        }
 
         private static void ExitApplication()
         {


### PR DESCRIPTION
Basic exit event catch (ctrl+c / ctrl+c+break) and exit command.